### PR TITLE
Add FunctionExecutionContext model extension and factory method

### DIFF
--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -197,6 +197,9 @@
     <Content Include="targets\csharp\source\source\WsaReflectionExtensions.cs" />
     <Content Include="targets\csharp\templates\API.cs.ejs" />
     <Content Include="targets\csharp\templates\APIInstance.cs.ejs" />
+    <Content Include="targets\csharp\source\source\Extensions\Models\PlayFabCloudScriptModelsExtensions.cs.ejs">
+      <SubType>Code</SubType>
+    </Content>
     <Content Include="targets\csharp\templates\Enum.cs.ejs" />
     <Content Include="targets\csharp\templates\Errors.cs.ejs" />
     <Content Include="targets\csharp\templates\Model.cs.ejs" />
@@ -944,7 +947,9 @@
     <Folder Include="targets\csharp\" />
     <Folder Include="targets\csharp\source\" />
     <Folder Include="targets\csharp\source\source\" />
+    <Folder Include="targets\csharp\source\source\Extensions\Models\" />
     <Folder Include="targets\csharp\source\source\Json\" />
+    <Folder Include="targets\csharp\source\source\Extensions\" />
     <Folder Include="targets\csharp\source\source\PlayFabHttp\" />
     <Folder Include="targets\csharp\source\source\Properties\" />
     <Folder Include="targets\csharp\source\source\Uunit\" />

--- a/SDKGenerator.njsproj
+++ b/SDKGenerator.njsproj
@@ -197,9 +197,7 @@
     <Content Include="targets\csharp\source\source\WsaReflectionExtensions.cs" />
     <Content Include="targets\csharp\templates\API.cs.ejs" />
     <Content Include="targets\csharp\templates\APIInstance.cs.ejs" />
-    <Content Include="targets\csharp\source\source\Extensions\Models\PlayFabCloudScriptModelsExtensions.cs.ejs">
-      <SubType>Code</SubType>
-    </Content>
+    <Content Include="targets\csharp\source\source\Extensions\Models\PlayFabCloudScriptModelsExtensions.cs.ejs" />
     <Content Include="targets\csharp\templates\Enum.cs.ejs" />
     <Content Include="targets\csharp\templates\Errors.cs.ejs" />
     <Content Include="targets\csharp\templates\Model.cs.ejs" />

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -1,0 +1,61 @@
+﻿namespace PlayFab.CloudScriptModels
+{
+    public class FunctionExecutionContext<T>
+    {
+        public PlayFabApiSettings ApiSettings { get; private set; }
+
+        public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
+
+        public T FunctionArgument { get; set; }
+
+        protected FunctionExecutionContext() { }
+
+        public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create(System.Net.Http.HttpRequestMessage request)
+        {
+            string body = await request.Content.ReadAsStringAsync();
+            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
+            var settings = new PlayFabApiSettings
+            {
+                TitleId = contextInternal.TitleAuthentication.TitleId,
+                DeveloperSecretKey = contextInternal.TitleAuthentication.TitleSecretKey
+            };
+
+            // TODO: STATIC ENTITY TOKEN?
+            PlayFabSettings.staticPlayer.EntityToken = contextInternal.TitleAuthentication.TitleEntityToken;
+            return new FunctionExecutionContext<T>()
+            {
+                ApiSettings = settings,
+                CallerEntityProfile = contextInternal.CallerEntityProfile,
+                FunctionArgument = (T)contextInternal.FunctionArgument
+            };
+        }
+
+        private class FunctionExecutionContextInternal<V>
+        {
+            public TitleAuthentication TitleAuthentication { get; set; }
+
+            public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
+
+            public V FunctionArgument { get; set; }
+        }
+
+        private class FunctionExecutionContextInternal : FunctionExecutionContextInternal<object>
+        {
+        }
+
+        private class TitleAuthentication
+        {
+            public string TitleId { get; set; }
+            public string TitleSecretKey { get; set; }
+            public string TitleEntityToken { get; set; }
+        }
+    }
+
+    public class FunctionExecutionContext : FunctionExecutionContext<object>
+    {
+        public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create<T>(System.Net.Http.HttpRequestMessage request)
+        {
+            return await FunctionExecutionContext<T>.Create(request);
+        }
+    }
+}

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -16,12 +16,12 @@
             var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
             var settings = new PlayFabApiSettings
             {
-                TitleId = contextInternal.TitleAuthentication.TitleId,
-                DeveloperSecretKey = contextInternal.TitleAuthentication.TitleSecretKey
+                TitleId = contextInternal.TitleAuthenticationContext.Id,
+                DeveloperSecretKey = contextInternal.TitleAuthenticationContext.SecretKey
             };
 
             // TODO: STATIC ENTITY TOKEN?
-            PlayFabSettings.staticPlayer.EntityToken = contextInternal.TitleAuthentication.TitleEntityToken;
+            PlayFabSettings.staticPlayer.EntityToken = contextInternal.TitleAuthenticationContext.EntityToken;
             return new FunctionExecutionContext<T>()
             {
                 ApiSettings = settings,
@@ -32,7 +32,7 @@
 
         private class FunctionExecutionContextInternal<V>
         {
-            public TitleAuthentication TitleAuthentication { get; set; }
+            public TitleAuthenticationContext TitleAuthenticationContext { get; set; }
 
             public ProfilesModels.EntityProfileBody CallerEntityProfile { get; set; }
 
@@ -43,11 +43,11 @@
         {
         }
 
-        private class TitleAuthentication
+        private class TitleAuthenticationContext
         {
-            public string TitleId { get; set; }
-            public string TitleSecretKey { get; set; }
-            public string TitleEntityToken { get; set; }
+            public string Id { get; set; }
+            public string SecretKey { get; set; }
+            public string EntityToken { get; set; }
         }
     }
 

--- a/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
+++ b/targets/csharp/source/source/Extensions/Models/PlayFabCloudScriptModelsExtensions.cs.ejs
@@ -13,7 +13,7 @@
         public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create(System.Net.Http.HttpRequestMessage request)
         {
             string body = await request.Content.ReadAsStringAsync();
-            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal>(body);
+            var contextInternal = Json.PlayFabSimpleJson.DeserializeObject<FunctionExecutionContextInternal<T>>(body);
             var settings = new PlayFabApiSettings
             {
                 TitleId = contextInternal.TitleAuthenticationContext.Id,
@@ -26,7 +26,7 @@
             {
                 ApiSettings = settings,
                 CallerEntityProfile = contextInternal.CallerEntityProfile,
-                FunctionArgument = (T)contextInternal.FunctionArgument
+                FunctionArgument = contextInternal.FunctionArgument
             };
         }
 
@@ -53,9 +53,5 @@
 
     public class FunctionExecutionContext : FunctionExecutionContext<object>
     {
-        public static async System.Threading.Tasks.Task<FunctionExecutionContext<T>> Create<T>(System.Net.Http.HttpRequestMessage request)
-        {
-            return await FunctionExecutionContext<T>.Create(request);
-        }
     }
 }


### PR DESCRIPTION
Add a class under Extensions/Models/ that is in the PlayFab.CloudScriptModels namespace. 
This class serves two purposes:
1. Provide context for Azure Functions that are using the SDK to make further API calls back to Main Server
2. Simplify the creation of PlayFabApiSettings and provide a single instance for the developer to use throughout all further function calls using authentication information provided by Main Server, such as title ID, secret key, and entity token.